### PR TITLE
remove need to import instances

### DIFF
--- a/decoder/src/main/scala/com/rauchenberg/cupcatAvro/decoder/package.scala
+++ b/decoder/src/main/scala/com/rauchenberg/cupcatAvro/decoder/package.scala
@@ -1,0 +1,5 @@
+package com.rauchenberg.cupcatAvro
+
+import com.rauchenberg.cupcatAvro.decoder.instances.decoderInstances
+
+package object decoder extends decoderInstances

--- a/schema/src/main/scala/com/rauchenberg/cupcatAvro/schema/package.scala
+++ b/schema/src/main/scala/com/rauchenberg/cupcatAvro/schema/package.scala
@@ -1,11 +1,12 @@
 package com.rauchenberg.cupcatAvro
 
 import com.rauchenberg.cupcatAvro.common._
+import com.rauchenberg.cupcatAvro.schema.instances.schemaInstances
 import org.apache.avro.{Schema, SchemaBuilder}
 
 import scala.collection.JavaConverters._
 
-package object schema {
+package object schema extends schemaInstances {
 
   type SchemaResult = Result[Schema]
 

--- a/schema/src/test/scala/common/UnitSpecBase.scala
+++ b/schema/src/test/scala/common/UnitSpecBase.scala
@@ -1,8 +1,7 @@
 package common
 
-import cats.scalatest.EitherMatchers
-import com.rauchenberg.cupcatAvro.schema.instances.schemaInstances
+import cats.scalatest.{EitherMatchers, EitherValues}
 import org.scalatest.{Matchers, WordSpecLike}
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
-trait UnitSpecBase extends WordSpecLike with Matchers with EitherMatchers with schemaInstances with ScalaCheckPropertyChecks
+trait UnitSpecBase extends WordSpecLike with Matchers with EitherMatchers with EitherValues with ScalaCheckPropertyChecks


### PR DESCRIPTION
* for now make each modules package object extends the relevant instances
* might work better to make the main trait companion do this e.g. 
```scala
object AvroSchema extends schemaInstances
```
but i couldn't get that to work properly (tho i only spent 2 mins looking)
* could also put them in the companion, but this would make that class file huge and messy